### PR TITLE
Swipe gesture feedback UI

### DIFF
--- a/app/lib/screens/swipe_screen.dart
+++ b/app/lib/screens/swipe_screen.dart
@@ -234,7 +234,11 @@ class _SwipeScreenState extends State<SwipeScreen> {
                         horizontalThresholdPercentage,
                         verticalThresholdPercentage,
                       ) {
-                        return PostCard(post: _posts[index]);
+                        return PostCard(
+                          post: _posts[index],
+                          horizontalOffsetPercentage:
+                              horizontalThresholdPercentage,
+                        );
                       },
                     );
                   },

--- a/app/lib/widgets/post_card.dart
+++ b/app/lib/widgets/post_card.dart
@@ -7,9 +7,14 @@ class PostCard extends StatelessWidget {
   const PostCard({
     super.key,
     required this.post,
+    this.horizontalOffsetPercentage = 0,
   });
 
   final Post post;
+  final int horizontalOffsetPercentage;
+
+  static const _saveColor = Color(0xFF4CAF50);
+  static const _dropColor = Color(0xFFEF5350);
 
   void _showExpandedContent(BuildContext context) {
     showModalBottomSheet<void>(
@@ -43,14 +48,22 @@ class PostCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
+    final opacity = (horizontalOffsetPercentage.abs() / 100).clamp(0.0, 1.0);
 
+    final overlayColor = horizontalOffsetPercentage < 0 ? _saveColor : _dropColor;
     return Card(
       color: const Color(0xFF1E1E1E),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(16),
+        side: opacity > 0
+            ? BorderSide(
+                color: overlayColor.withOpacity(opacity),
+                width: 2,
+              )
+            : BorderSide.none,
       ),
       child: Padding(
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.all(20),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -61,26 +74,41 @@ class PostCard extends StatelessWidget {
                 fontWeight: FontWeight.bold,
               ),
             ),
-            const SizedBox(height: 12),
+            const Divider(color: Colors.white12),
             Text(
               post.summary,
-              style: textTheme.bodyLarge,
+              style: textTheme.bodyLarge?.copyWith(height: 1.5),
             ),
             const SizedBox(height: 16),
-            Row(
-              children: [
-                TextButton(
-                  onPressed: () => _showExpandedContent(context),
-                  child: const Text('더보기'),
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton.icon(
+                onPressed: () => _showExpandedContent(context),
+                icon: const Icon(Icons.expand_more),
+                label: const Text('더보기'),
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: Colors.white70,
+                  side: const BorderSide(color: Colors.white24),
+                  shape: const StadiumBorder(),
                 ),
-                const Spacer(),
-                if (post.postUrl != null)
-                  TextButton(
-                    onPressed: _openPostUrl,
-                    child: const Text('Link'),
-                  ),
-              ],
+              ),
             ),
+            if (post.postUrl != null) ...[
+              const SizedBox(height: 8),
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton.icon(
+                  onPressed: _openPostUrl,
+                  icon: const Icon(Icons.open_in_new),
+                  label: const Text('LinkedIn에서 보기'),
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: Colors.white70,
+                    side: const BorderSide(color: Colors.white24),
+                    shape: const StadiumBorder(),
+                  ),
+                ),
+              ),
+            ],
           ],
         ),
       ),

--- a/app/test/post_card_test.dart
+++ b/app/test/post_card_test.dart
@@ -21,13 +21,20 @@ Post _buildPost({String? postUrl = 'https://linkedin.com/posts/post-1'}) {
   );
 }
 
-Future<void> _pumpPostCard(WidgetTester tester, Post post) async {
+Future<void> _pumpPostCard(
+  WidgetTester tester,
+  Post post, {
+  int horizontalOffsetPercentage = 0,
+}) async {
   await tester.pumpWidget(
     MaterialApp(
       theme: ThemeData(useMaterial3: false),
       home: Scaffold(
         body: Center(
-          child: PostCard(post: post),
+          child: PostCard(
+            post: post,
+            horizontalOffsetPercentage: horizontalOffsetPercentage,
+          ),
         ),
       ),
     ),
@@ -44,7 +51,7 @@ void main() {
     expect(find.text('Jane Doe'), findsOneWidget);
     expect(find.text('Short AI summary'), findsOneWidget);
     expect(find.text('더보기'), findsOneWidget);
-    expect(find.text('Link'), findsOneWidget);
+    expect(find.text('LinkedIn에서 보기'), findsOneWidget);
   });
 
   testWidgets('opens ExpandedContent bottom sheet with full post text', (
@@ -59,12 +66,12 @@ void main() {
     expect(find.text('This is the full post body text'), findsOneWidget);
   });
 
-  testWidgets('hides Link button when postUrl is null',
+  testWidgets('hides LinkedIn button when postUrl is null',
       (WidgetTester tester) async {
     await _pumpPostCard(tester, _buildPost(postUrl: null));
 
     expect(find.text('더보기'), findsOneWidget);
-    expect(find.text('Link'), findsNothing);
+    expect(find.text('LinkedIn에서 보기'), findsNothing);
   });
 
   testWidgets('uses dark card color rounded corners and readable padding', (
@@ -86,8 +93,50 @@ void main() {
     );
 
     final hasReadablePadding = paddings.any(
-      (padding) => padding.padding == const EdgeInsets.all(16),
+      (padding) => padding.padding == const EdgeInsets.all(20),
     );
     expect(hasReadablePadding, isTrue);
+  });
+
+  testWidgets('shows green border when dragged left', (
+    WidgetTester tester,
+  ) async {
+    await _pumpPostCard(tester, _buildPost(), horizontalOffsetPercentage: -50);
+
+    final card = tester.widget<Card>(find.byType(Card));
+    final shape = card.shape as RoundedRectangleBorder;
+    expect(shape.side.color, const Color(0xFF4CAF50).withOpacity(0.5));
+    expect(shape.side.width, 2);
+  });
+
+  testWidgets('shows red border when dragged right', (
+    WidgetTester tester,
+  ) async {
+    await _pumpPostCard(tester, _buildPost(), horizontalOffsetPercentage: 50);
+
+    final card = tester.widget<Card>(find.byType(Card));
+    final shape = card.shape as RoundedRectangleBorder;
+    expect(shape.side.color, const Color(0xFFEF5350).withOpacity(0.5));
+    expect(shape.side.width, 2);
+  });
+
+  testWidgets('shows no border when offset is zero', (
+    WidgetTester tester,
+  ) async {
+    await _pumpPostCard(tester, _buildPost(), horizontalOffsetPercentage: 0);
+
+    final card = tester.widget<Card>(find.byType(Card));
+    final shape = card.shape as RoundedRectangleBorder;
+    expect(shape.side, BorderSide.none);
+  });
+
+  testWidgets('buttons are vertically stacked with outlined style', (
+    WidgetTester tester,
+  ) async {
+    await _pumpPostCard(tester, _buildPost());
+
+    expect(find.text('더보기'), findsOneWidget);
+    expect(find.text('LinkedIn에서 보기'), findsOneWidget);
+    expect(find.byType(OutlinedButton), findsNWidgets(2));
   });
 }


### PR DESCRIPTION
## Summary
- Add colored border glow on swipe: green for save (left), red for drop (right), with opacity proportional to drag distance
- Redesign PostCard layout: increased padding, author-summary divider, vertical outlined buttons, renamed LinkedIn button
- Pass `horizontalOffsetPercentage` from `CardSwiper` cardBuilder to `PostCard`
- Update and add tests for new UI behavior

## Original Issue
Refactor noise-cancel app design.
왼쪽 오른쪽 갈때 왼쪽이면 초록색으로 프리뷰?처럼 나오면서 저장될 것 같은 표시가, 오른쪽으로 가면 빨간색으로 삭제된다는 표시가 뜨면 좋겠음.

## Test plan
- [x] All 37 Flutter tests pass (`flutter test`)
- [ ] Verify green border glow on left swipe (save) on device
- [ ] Verify red border glow on right swipe (drop) on device
- [ ] Confirm no overlay overlap with card content

close #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)